### PR TITLE
Add wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[wheel]
+universal = 1
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,22 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = '0.5.1'
 
 
+if sys.argv[-1] == 'publish':
+    os.system('python setup.py sdist bdist_wheel upload')
+    print "You should also consider tagging a release:"
+    print "  git tag -a %s -m 'version %s'" % (VERSION, VERSION)
+    print "  git push --tags"
+    sys.exit()
+
+
 setup(
     name='nose-picker',
     version=VERSION,
-    classifiers=['License :: OSI Approved :: BSD License'],
+    classifiers=[
+        'License :: OSI Approved :: BSD License'
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+    ],
     long_description=README,
     url='https://github.com/eventbrite/nose-picker',
     license='BSD',


### PR DESCRIPTION
- Added publish option for setup.py that puts both standard and wheel packages on PyPI. Operates via `python setup.py publish`
- Added Python 2.6 and 2.7 (I tested there) in trove classifiers to make discovery easier.
