### PR TITLE
Add optional --file-durations flag for duration-aware bin-packing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,57 @@ running through, does a modulo division by N, then sees if this file is "its".
 Very simple, but it lets you run multiple of these **nose-picker** enabled
 runners in parallel, each running a separate subset of the unit tests!
 
+Optional: duration-aware bin-packing (``--file-durations``)
+-------------------------------------------------------------
+
+By default (and if you do nothing differently), **nose-picker** still just
+hashes each candidate file's path and mods it by ``--total-processes`` --
+completely unchanged from prior releases. If your files vary a lot in how
+long they take to run, hashing can produce very unbalanced shards even
+though each shard gets roughly the same *number* of files.
+
+As of 0.6.0, you can opt in to duration-aware bin-packing instead::
+
+    --file-durations=/path/to/durations.json
+
+where ``durations.json`` looks like::
+
+    {
+        "/ebapps/foo/tests/test_bar.py": 12.34,
+        "/common/tests/test_baz.py": 0.87
+    }
+
+(keys are relative paths using the same "strip the cwd/site-packages prefix"
+convention ``hash_filename()`` has always used).
+
+When given a valid file, nose-picker walks the current working directory
+once, up front (during nose's plugin ``configure()`` step, before test
+collection starts), building the same file candidate list nose's own default
+discovery convention would produce, and greedily bin-packs those files across
+``--total-processes`` bins by descending duration (longest processing time
+first), so each shard ends up with roughly the same *total* runtime instead
+of roughly the same file count. Files with no entry in the durations table
+are weighted with the median of all known durations, and a warning is logged
+(via the ``nose.plugins.picker`` logger) if too large a fraction of the
+discovered files are missing from the table, since that's a sign the table
+has gone stale.
+
+**Backward compatibility guarantee**: if ``--file-durations`` is not passed,
+or the given path doesn't exist, can't be read, or doesn't parse as JSON,
+behavior is *exactly* the classic hash-modulo selection, unchanged. This is
+deliberate and load-bearing: nose-picker has other consumers besides the one
+that motivated this feature, and none of them should see any behavior change
+unless they explicitly pass the new flag.
+
+**Known ceiling**: bin-packing here only ever operates at whole-file
+granularity, because nose only ever asks this plugin "do you want this
+file?" one file at a time -- there's no hook to split a single file's tests
+across shards. If one test file alone takes far longer to run than an even
+share of the total suite, no bin-packing scheme built on this hook can even
+out wall-clock time; that file's own duration becomes a floor for whatever
+shard it lands in. Bin-packing helps a lot when slowness is spread across
+many files, much less when it's concentrated in one.
+
 Motivation
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -38,17 +38,39 @@ where ``durations.json`` looks like::
 (keys are relative paths using the same "strip the cwd/site-packages prefix"
 convention ``hash_filename()`` has always used).
 
-When given a valid file, nose-picker walks the current working directory
-once, up front (during nose's plugin ``configure()`` step, before test
-collection starts), building the same file candidate list nose's own default
-discovery convention would produce, and greedily bin-packs those files across
-``--total-processes`` bins by descending duration (longest processing time
-first), so each shard ends up with roughly the same *total* runtime instead
-of roughly the same file count. Files with no entry in the durations table
-are weighted with the median of all known durations, and a warning is logged
-(via the ``nose.plugins.picker`` logger) if too large a fraction of the
-discovered files are missing from the table, since that's a sign the table
-has gone stale.
+When given a valid file, nose-picker does **not** try to rediscover your test
+files itself. Instead, in nose's plugin ``configure()`` step (before test
+collection starts), it bin-packs the durations table's own set of files --
+real ground truth captured from an actual prior nose run's output, not a
+guess -- across ``--total-processes`` bins by descending duration (longest
+processing time first), so each shard ends up with roughly the same *total*
+runtime instead of roughly the same file count. Nose's own real
+discovery keeps driving everything else exactly as before: it still calls
+this plugin's ``wantFile()`` hook once per file, one at a time, as its own
+``Loader``/``Selector`` finds each one. For a file the durations table
+already covers, ``wantFile()`` becomes a simple membership check against the
+precomputed assignment; for a file the table *doesn't* cover (new since the
+table was last refreshed, or any other reason), that one file falls back to
+the classic hash so it still runs in exactly one shard rather than
+vanishing from all of them. Files with no entry in the table are weighted
+with the median of all known durations at bin-packing time (if there aren't
+enough of them to make bin-packing meaningless -- see below), and a
+staleness warning is logged (via the ``nose.plugins.picker`` logger, at the
+end of the run, from nose's standard ``report()`` plugin hook) if too large
+a fraction of the files actually visited this run fell back to the hash
+individually, since that's a sign the table has gone stale.
+
+An earlier version of this feature had nose-picker walk the filesystem
+itself to build a candidate list, reimplementing nose's own default
+discovery convention (``testMatch``/``ignoreFiles``/``srcDirs``/package
+detection). That was dropped in favor of the design above: any mismatch
+between a hand-rolled reimplementation and nose's *actual* discovery
+behavior (custom ``--match``/``--include``/``--exclude`` regexes, other
+plugins' directory exclusions, subtle edge cases) risked a file nose really
+does visit never appearing in *any* shard's assigned set -- a correctness
+bug, not just a balance one. Deriving the candidate set from the durations
+table itself, and leaving 100% of real discovery to nose as it's always
+worked, removes that entire risk category.
 
 **Backward compatibility guarantee**: if ``--file-durations`` is not passed,
 or the given path doesn't exist, can't be read, or doesn't parse as JSON,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
-VERSION = '0.5.7'
+VERSION = '0.6.0'
 
 
 if sys.argv[-1] == 'publish':

--- a/src/picker/nose_plugin.py
+++ b/src/picker/nose_plugin.py
@@ -31,11 +31,41 @@
 from __future__ import absolute_import
 import six
 import hashlib
+import json
 import logging
 import os
+import re
 import site
+import stat
+import sys
 
 from nose.plugins import Plugin
+
+
+# ---------------------------------------------------------------------------
+# Path normalization shared by the hash-based path and the duration-based
+# (bin-packing) path, so that JSON keys in a --file-durations file line up
+# exactly with the paths hash_filename() has always used.
+# ---------------------------------------------------------------------------
+
+def _relative_key(filename, cwd=None):
+    '''Strip filename down to the same "portable" relative path that
+    hash_filename() has always hashed: the part of the (real, absolute) path
+    after the current working directory (or, failing that, after whichever
+    site-packages directory it lives under).
+    '''
+    working_dir = cwd if cwd is not None else os.getcwd()
+    here = os.path.realpath(working_dir)
+    there = os.path.realpath(filename)
+    if not there.startswith(here):
+        for path in site.getsitepackages():
+            if there.startswith(path):
+                here = path
+    assert there.startswith(here), "{} must start with {} or be in site packages".format(
+        there,
+        os.path.realpath(working_dir),
+    )
+    return there[len(here):]
 
 
 def hash_filename(filename):
@@ -48,20 +78,199 @@ def hash_filename(filename):
     To achieve that, it assumes that filename is a sub-path of the current working directory or site packages,
     and then removes the current working directory from the path.
     '''
-    here = os.path.realpath(os.getcwd())
-    there = os.path.realpath(filename)
-    if not there.startswith(here):
-        for path in site.getsitepackages():
-            if there.startswith(path):
-                here = path
-    assert there.startswith(here), "{} must start with {} or be in site packages".format(
-        there,
-        os.path.realpath(os.getcwd()),
-    )
-
-    shorter_there = six.ensure_binary(there[len(here):])
+    shorter_there = six.ensure_binary(_relative_key(filename))
     as_int = int(hashlib.sha1(shorter_there).hexdigest(), 16)
     return as_int
+
+
+# ---------------------------------------------------------------------------
+# Best-effort reimplementation of nose's *default* file-discovery convention
+# (nose.selector.Selector.wantFile / wantDirectory, nose.util.ispackage, and
+# nose.config.Config's built-in ignoreFiles/testMatch/srcDirs), used only to
+# build the complete candidate-file list up front for --file-durations
+# bin-packing. This intentionally mirrors nose 1.3.7's defaults; it does NOT
+# know about custom --match/--include/--exclude regexes, or directory
+# exclusions contributed by other plugins (e.g. nose-exclude's --exclude-dir)
+# on top of those defaults. See README for the known gap this leaves.
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_DEFAULT_TESTMATCH_RE = re.compile(r'(?:^|[\b_\.%s-])[Tt]est' % os.sep)
+_DEFAULT_IGNORE_FILE_RES = (
+    re.compile(r'^\.'),
+    re.compile(r'^_'),
+    re.compile(r'^setup\.py$'),
+)
+_DEFAULT_SRC_DIRS = ('lib', 'src')
+_EXE_ALLOWED_PLATFORMS = ('win32', 'cli')
+
+
+def _is_package_dir(path):
+    end = os.path.basename(path)
+    if not _IDENT_RE.match(end):
+        return False
+    for init in ('__init__.py', '__init__.pyc', '__init__.pyo'):
+        if os.path.isfile(os.path.join(path, init)):
+            return True
+    return False
+
+
+def _is_executable(path):
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    return bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def _wants_file(basename, fullpath):
+    for ignore_re in _DEFAULT_IGNORE_FILE_RES:
+        if ignore_re.search(basename):
+            return False
+    if sys.platform not in _EXE_ALLOWED_PLATFORMS and _is_executable(fullpath):
+        return False
+    if not basename.endswith('.py'):
+        return False
+    return bool(_DEFAULT_TESTMATCH_RE.search(basename))
+
+
+def _wants_directory(basename, fullpath):
+    if _is_package_dir(fullpath):
+        return True
+    return bool(_DEFAULT_TESTMATCH_RE.search(basename)) or basename in _DEFAULT_SRC_DIRS
+
+
+def discover_candidate_files(root):
+    '''Walk `root` and return the list of full paths for every file that
+    nose's *default* discovery convention would hand to wantFile -- i.e. the
+    complete candidate set that --which-process/--total-processes selection
+    has always operated over one file at a time, without ever seeing the
+    full list.
+    '''
+    root = os.path.realpath(root)
+    candidates = []
+    visited_dirs = set()
+
+    def _walk(path):
+        real = os.path.realpath(path)
+        if real in visited_dirs:
+            return
+        visited_dirs.add(real)
+        try:
+            entries = sorted(os.listdir(path))
+        except OSError:
+            return
+        for entry in entries:
+            if entry.startswith('.'):
+                continue
+            entry_path = os.path.join(path, entry)
+            if os.path.isfile(entry_path):
+                if _wants_file(entry, entry_path):
+                    candidates.append(entry_path)
+            elif os.path.isdir(entry_path):
+                if entry.startswith('_'):
+                    continue
+                if _wants_directory(entry, entry_path):
+                    _walk(entry_path)
+
+    _walk(root)
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Duration-aware bin-packing (LPT: longest processing time first).
+# ---------------------------------------------------------------------------
+
+def _median(values):
+    '''No `statistics` module: this needs to run on Python 2.7.'''
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    count = len(ordered)
+    mid = count // 2
+    if count % 2:
+        return float(ordered[mid])
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _load_durations_file(path, logger):
+    '''Load {relative_file_path: total_seconds} from `path`. Returns None
+    (and logs why) on any failure, so callers can fall back to the classic
+    hash-based behavior -- this must never raise.
+    '''
+    if not path:
+        return None
+    try:
+        with open(path, 'r') as fh:
+            raw = json.load(fh)
+    except (IOError, OSError) as exc:
+        logger.warning(
+            'nose-picker: --file-durations=%s could not be read (%s); '
+            'falling back to hash-based file selection.', path, exc,
+        )
+        return None
+    except ValueError as exc:  # json.JSONDecodeError is a ValueError subclass
+        logger.warning(
+            'nose-picker: --file-durations=%s is not valid JSON (%s); '
+            'falling back to hash-based file selection.', path, exc,
+        )
+        return None
+
+    if not isinstance(raw, dict):
+        logger.warning(
+            'nose-picker: --file-durations=%s did not contain a JSON object; '
+            'falling back to hash-based file selection.', path,
+        )
+        return None
+
+    durations = {}
+    for key, value in raw.items():
+        try:
+            durations[key] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return durations
+
+
+def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_threshold=0.30):
+    '''Greedy LPT bin-packing: sort candidates descending by known/estimated
+    weight (ties broken by path for determinism), then repeatedly place the
+    next-heaviest file into whichever bin currently has the smallest total.
+
+    Files with no entry in `durations` are weighted with the median of all
+    known durations, and a warning is logged if too large a fraction of the
+    candidate set is unknown (a sign the durations table is stale).
+
+    NOTE: this only balances at file granularity. A single very slow test
+    file can never be split across bins, so no bin-packing scheme built on
+    top of nose's per-file wantFile() hook can fully even out wall-clock time
+    if one file dominates -- see the PR description / README for this ceiling.
+    '''
+    known_values = [durations[k] for k in candidate_keys if k in durations]
+    fallback_weight = _median(known_values)
+    missing = [k for k in candidate_keys if k not in durations]
+
+    if candidate_keys and missing:
+        stale_fraction = len(missing) / float(len(candidate_keys))
+        if stale_fraction > stale_threshold:
+            logger.warning(
+                'nose-picker: %d/%d discovered test files (%.0f%%) have no entry '
+                'in the --file-durations table and are being weighted with the '
+                'median known duration (%.3fs); the durations cache may be stale.',
+                len(missing), len(candidate_keys), stale_fraction * 100.0, fallback_weight,
+            )
+
+    weights = dict((key, durations.get(key, fallback_weight)) for key in candidate_keys)
+    ordered = sorted(candidate_keys, key=lambda key: (-weights[key], key))
+
+    bin_totals = [0.0] * total_processes
+    bin_files = [[] for _ in range(total_processes)]
+    for key in ordered:
+        target = bin_totals.index(min(bin_totals))
+        bin_totals[target] += weights[key]
+        bin_files[target].append(key)
+
+    return bin_files, bin_totals
 
 
 class NosePicker(Plugin):
@@ -71,6 +280,8 @@ class NosePicker(Plugin):
         self.output = True
         self.enableOpt = 'with-nose-picker'
         self.logger = logging.getLogger('nose.plugins.picker')
+        self._assigned_files = None
+        self._all_candidate_keys = frozenset()
 
     def options(self, parser, env=os.environ):
         parser.add_option(
@@ -91,12 +302,30 @@ class NosePicker(Plugin):
             dest='total_processes',
             help='nose-picker: How many total processes to run with.',
         )
+        parser.add_option(
+            '--file-durations',
+            type='string',
+            dest='file_durations',
+            default=None,
+            help=(
+                'nose-picker: Optional path to a JSON file mapping relative test '
+                'file paths (the same convention hash_filename() strips paths '
+                'down to) to their most recent total run duration in seconds. '
+                'When given a valid file, nose-picker bin-packs the full set of '
+                'discovered test files across --total-processes bins by duration '
+                '(greedy LPT) instead of hashing filenames. If this flag is '
+                'omitted, or the file is missing/unreadable/invalid, behavior is '
+                'unchanged from the classic hash-modulo selection.'
+            ),
+        )
         super(NosePicker, self).options(parser, env=env)
 
     def configure(self, options, config):
         self.enabled = getattr(options, self.enableOpt)
         self.total_processes = options.total_processes
         self.which_process = options.which_process
+        self._assigned_files = None
+        self._all_candidate_keys = frozenset()
 
         if options.futz_with_django:
             import django
@@ -114,7 +343,55 @@ class NosePicker(Plugin):
                 else:
                     connection.settings_dict['TEST_NAME'] = test_alias
 
+        file_durations_path = getattr(options, 'file_durations', None)
+        if self.enabled and file_durations_path:
+            # Anything going wrong here -- a bad walk, an unreadable path, a
+            # bug in the bin-packer -- must degrade to the classic hash
+            # behavior, never take the whole test run down. This is the
+            # backward-compat guarantee for everyone who hasn't opted in.
+            try:
+                self._configure_file_durations(file_durations_path)
+            except Exception:
+                self.logger.warning(
+                    'nose-picker: unexpected error configuring '
+                    '--file-durations=%s; falling back to hash-based file '
+                    'selection.', file_durations_path, exc_info=True,
+                )
+                self._assigned_files = None
+                self._all_candidate_keys = frozenset()
+
         super(NosePicker, self).configure(options, config)
+
+    def _configure_file_durations(self, file_durations_path):
+        durations = _load_durations_file(file_durations_path, self.logger)
+        if durations is None:
+            return
+
+        candidate_paths = discover_candidate_files(os.getcwd())
+        candidate_keys = [_relative_key(path) for path in candidate_paths]
+
+        if not (0 <= self.which_process < self.total_processes):
+            self.logger.warning(
+                'nose-picker: which_process=%s is out of range for '
+                'total_processes=%s; falling back to hash-based file '
+                'selection.', self.which_process, self.total_processes,
+            )
+            return
+
+        bins, totals = _bin_pack_files(
+            candidate_keys, durations, self.total_processes, self.logger,
+        )
+        self._assigned_files = frozenset(bins[self.which_process])
+        self._all_candidate_keys = frozenset(candidate_keys)
+        self.logger.info(
+            'nose-picker: --file-durations bin-packing active; process %d/%d '
+            'assigned %d of %d discovered files, totalling %.1fs (all bin '
+            'totals: %s)',
+            self.which_process, self.total_processes,
+            len(bins[self.which_process]), len(candidate_keys),
+            totals[self.which_process],
+            ', '.join('%.1f' % total for total in totals),
+        )
 
     def wantFile(self, fullpath):
         """
@@ -124,9 +401,25 @@ class NosePicker(Plugin):
 
     def _should_run(self, name):
         if self.enabled:
-            hashed_value = hash_filename(name) % self.total_processes
-            if hashed_value == self.which_process:
-                return None
-            return False
+            if self._assigned_files is not None:
+                key = _relative_key(name)
+                if key in self._all_candidate_keys:
+                    if key in self._assigned_files:
+                        return None
+                    return False
+                # This file exists (nose is asking about it) but our own
+                # upfront walk didn't enumerate it -- e.g. it was added after
+                # configure() ran, or our reimplementation of nose's
+                # discovery conventions missed a case. Fall back to the hash
+                # for this one file so it still runs in exactly one shard
+                # instead of silently vanishing from all of them.
+                return self._hash_should_run(name)
+            return self._hash_should_run(name)
 
         return None
+
+    def _hash_should_run(self, name):
+        hashed_value = hash_filename(name) % self.total_processes
+        if hashed_value == self.which_process:
+            return None
+        return False

--- a/src/picker/nose_plugin.py
+++ b/src/picker/nose_plugin.py
@@ -34,10 +34,7 @@ import hashlib
 import json
 import logging
 import os
-import re
 import site
-import stat
-import sys
 
 from nose.plugins import Plugin
 
@@ -84,113 +81,35 @@ def hash_filename(filename):
 
 
 # ---------------------------------------------------------------------------
-# Best-effort reimplementation of nose's *default* file-discovery convention
-# (nose.selector.Selector.wantFile / wantDirectory, nose.util.ispackage, and
-# nose.config.Config's built-in ignoreFiles/testMatch/srcDirs), used only to
-# build the complete candidate-file list up front for --file-durations
-# bin-packing. This intentionally mirrors nose 1.3.7's defaults; it does NOT
-# know about custom --match/--include/--exclude regexes, or directory
-# exclusions contributed by other plugins (e.g. nose-exclude's --exclude-dir)
-# on top of those defaults. See README for the known gap this leaves.
-# ---------------------------------------------------------------------------
-
-_IDENT_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
-_DEFAULT_TESTMATCH_RE = re.compile(r'(?:^|[\b_\.%s-])[Tt]est' % os.sep)
-_DEFAULT_IGNORE_FILE_RES = (
-    re.compile(r'^\.'),
-    re.compile(r'^_'),
-    re.compile(r'^setup\.py$'),
-)
-_DEFAULT_SRC_DIRS = ('lib', 'src')
-_EXE_ALLOWED_PLATFORMS = ('win32', 'cli')
-
-
-def _is_package_dir(path):
-    end = os.path.basename(path)
-    if not _IDENT_RE.match(end):
-        return False
-    for init in ('__init__.py', '__init__.pyc', '__init__.pyo'):
-        if os.path.isfile(os.path.join(path, init)):
-            return True
-    return False
-
-
-def _is_executable(path):
-    try:
-        st = os.stat(path)
-    except OSError:
-        return False
-    return bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
-
-
-def _wants_file(basename, fullpath):
-    for ignore_re in _DEFAULT_IGNORE_FILE_RES:
-        if ignore_re.search(basename):
-            return False
-    if sys.platform not in _EXE_ALLOWED_PLATFORMS and _is_executable(fullpath):
-        return False
-    if not basename.endswith('.py'):
-        return False
-    return bool(_DEFAULT_TESTMATCH_RE.search(basename))
-
-
-def _wants_directory(basename, fullpath):
-    if _is_package_dir(fullpath):
-        return True
-    return bool(_DEFAULT_TESTMATCH_RE.search(basename)) or basename in _DEFAULT_SRC_DIRS
-
-
-def discover_candidate_files(root):
-    '''Walk `root` and return the list of full paths for every file that
-    nose's *default* discovery convention would hand to wantFile -- i.e. the
-    complete candidate set that --which-process/--total-processes selection
-    has always operated over one file at a time, without ever seeing the
-    full list.
-
-    Dedupes by os.path.realpath() at both directory and file granularity, so
-    a symlink (a symlinked directory anywhere on the path, or a direct
-    symlink to a file) can never produce two separate entries for what's
-    really the same underlying file -- exactly the same realpath-based
-    identity hash_filename()/_relative_key() already use elsewhere in this
-    module, applied here too so callers never see duplicate candidates.
-    '''
-    root = os.path.realpath(root)
-    candidates = []
-    visited_dirs = set()
-    visited_files = set()
-
-    def _walk(path):
-        real = os.path.realpath(path)
-        if real in visited_dirs:
-            return
-        visited_dirs.add(real)
-        try:
-            entries = sorted(os.listdir(path))
-        except OSError:
-            return
-        for entry in entries:
-            if entry.startswith('.'):
-                continue
-            entry_path = os.path.join(path, entry)
-            if os.path.isfile(entry_path):
-                if _wants_file(entry, entry_path):
-                    real_file = os.path.realpath(entry_path)
-                    if real_file in visited_files:
-                        continue
-                    visited_files.add(real_file)
-                    candidates.append(entry_path)
-            elif os.path.isdir(entry_path):
-                if entry.startswith('_'):
-                    continue
-                if _wants_directory(entry, entry_path):
-                    _walk(entry_path)
-
-    _walk(root)
-    return candidates
-
-
-# ---------------------------------------------------------------------------
 # Duration-aware bin-packing (LPT: longest processing time first).
+#
+# Design note: nose-picker deliberately does NOT do its own filesystem walk
+# to build a candidate-file list. An earlier version of this feature did --
+# reimplementing nose's default discovery convention (testMatch/ignoreFiles/
+# srcDirs/package detection) well enough to build a complete file list up
+# front, since nose's own wantFile() plugin hook only ever hands files over
+# one at a time, as nose's own real walk discovers them. That reimplementation
+# risked silently diverging from nose's actual behavior (custom --match/
+# --include/--exclude regexes, other plugins' directory exclusions, subtle
+# edge cases) -- a mismatch there means some file nose really does visit
+# never appearing in *any* shard's assigned set, which is a correctness bug,
+# not just a balance one.
+#
+# Instead: nose's own real discovery keeps driving everything exactly as it
+# always has (wantFile() is still called once per file, one at a time, as
+# nose's own Loader/Selector finds it -- nose-picker never walks anything
+# itself). The candidate set used for bin-packing is simply the key set of
+# the --file-durations table itself: real ground truth captured from an
+# actual prior nose run's junit output (see eventbrite/core's CI wiring),
+# not a guess about what nose would discover. Bin-packing happens once, in
+# configure(), over that known key set. As nose's real walk then calls
+# wantFile() file by file, _should_run() looks the file up in the
+# precomputed assignment; a file nose visits that ISN'T in that known set
+# (new since the durations table was last refreshed, or the table doesn't
+# cover it for any other reason) falls back to the classic hash for that one
+# file -- the same safety net as the "unknown file" case, but now the
+# *expected*, routine path for new files rather than a reimplementation-bug
+# escape hatch.
 # ---------------------------------------------------------------------------
 
 def _median(values):
@@ -251,7 +170,12 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
 
     Files with no entry in `durations` are weighted with the median of all
     known durations, and a warning is logged if too large a fraction of the
-    candidate set is unknown (a sign the durations table is stale).
+    candidate set is unknown (a sign the durations table is stale). In
+    practice `candidate_keys` is normally exactly `durations.keys()` (see the
+    module docstring above), so this path rarely triggers today -- it's kept
+    general because it's also independently unit-tested, and because a
+    caller passing a candidate set that only partially overlaps `durations`
+    is a perfectly reasonable thing to support.
 
     NOTE: this only balances at file granularity. A single very slow test
     file can never be split across bins, so no bin-packing scheme built on
@@ -275,7 +199,7 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
         # improve on. Signal "can't bin-pack" to the caller so it falls back
         # to classic hash-based selection instead.
         logger.warning(
-            'nose-picker: no usable durations found among %d discovered test '
+            'nose-picker: no usable durations found among %d candidate test '
             'files; falling back to hash-based file selection.',
             len(candidate_keys),
         )
@@ -288,7 +212,7 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
         stale_fraction = len(missing) / float(len(candidate_keys))
         if stale_fraction > stale_threshold:
             logger.warning(
-                'nose-picker: %d/%d discovered test files (%.0f%%) have no entry '
+                'nose-picker: %d/%d candidate test files (%.0f%%) have no entry '
                 'in the --file-durations table and are being weighted with the '
                 'median known duration (%.3fs); the durations cache may be stale.',
                 len(missing), len(candidate_keys), stale_fraction * 100.0, fallback_weight,
@@ -328,7 +252,9 @@ class NosePicker(Plugin):
         self.enableOpt = 'with-nose-picker'
         self.logger = logging.getLogger('nose.plugins.picker')
         self._assigned_files = None
-        self._all_candidate_keys = frozenset()
+        self._known_keys = frozenset()
+        self._known_hits = 0
+        self._unknown_hits = 0
 
     def options(self, parser, env=os.environ):
         parser.add_option(
@@ -358,11 +284,12 @@ class NosePicker(Plugin):
                 'nose-picker: Optional path to a JSON file mapping relative test '
                 'file paths (the same convention hash_filename() strips paths '
                 'down to) to their most recent total run duration in seconds. '
-                'When given a valid file, nose-picker bin-packs the full set of '
-                'discovered test files across --total-processes bins by duration '
-                '(greedy LPT) instead of hashing filenames. If this flag is '
-                'omitted, or the file is missing/unreadable/invalid, behavior is '
-                'unchanged from the classic hash-modulo selection.'
+                'When given a valid file, nose-picker bin-packs that file set '
+                'across --total-processes bins by duration (greedy LPT) instead '
+                'of hashing filenames; files nose visits that this run\'s table '
+                'doesn\'t cover still fall back to the hash individually. If this '
+                'flag is omitted, or the file is missing/unreadable/invalid, '
+                'behavior is unchanged from the classic hash-modulo selection.'
             ),
         )
         super(NosePicker, self).options(parser, env=env)
@@ -372,7 +299,9 @@ class NosePicker(Plugin):
         self.total_processes = options.total_processes
         self.which_process = options.which_process
         self._assigned_files = None
-        self._all_candidate_keys = frozenset()
+        self._known_keys = frozenset()
+        self._known_hits = 0
+        self._unknown_hits = 0
 
         if options.futz_with_django:
             import django
@@ -392,10 +321,10 @@ class NosePicker(Plugin):
 
         file_durations_path = getattr(options, 'file_durations', None)
         if self.enabled and file_durations_path:
-            # Anything going wrong here -- a bad walk, an unreadable path, a
-            # bug in the bin-packer -- must degrade to the classic hash
-            # behavior, never take the whole test run down. This is the
-            # backward-compat guarantee for everyone who hasn't opted in.
+            # Anything going wrong here -- an unreadable path, a bug in the
+            # bin-packer -- must degrade to the classic hash behavior, never
+            # take the whole test run down. This is the backward-compat
+            # guarantee for everyone who hasn't opted in.
             try:
                 self._configure_file_durations(file_durations_path)
             except Exception:
@@ -405,7 +334,7 @@ class NosePicker(Plugin):
                     'selection.', file_durations_path, exc_info=True,
                 )
                 self._assigned_files = None
-                self._all_candidate_keys = frozenset()
+                self._known_keys = frozenset()
 
         super(NosePicker, self).configure(options, config)
 
@@ -414,18 +343,10 @@ class NosePicker(Plugin):
         if durations is None:
             return
 
-        # discover_candidate_files() already dedupes by os.path.realpath() at both directory and
-        # file granularity (see its docstring), so a symlink and its target can never appear as
-        # two separate entries here -- each candidate_keys entry (itself realpath-derived, via
-        # _relative_key()) is guaranteed unique. That invariant matters: without it,
-        # _bin_pack_files could place two occurrences of what's really one physical file into
-        # different bins, and two shards would each believe they own it and both run it. Legacy
-        # hash mode never had this failure mode (hash_filename() is realpath-based too, so a
-        # symlink and its target always hash identically and land on one shard together) --
-        # duration mode needs to preserve that same guarantee itself, which is what
-        # discover_candidate_files()'s dedup is for.
-        candidate_paths = discover_candidate_files(os.getcwd())
-        candidate_keys = [_relative_key(path) for path in candidate_paths]
+        # The candidate set is exactly the durations table's own keys -- real ground truth from
+        # an actual prior nose run (see the module docstring above for why nose-picker doesn't do
+        # its own filesystem walk to build this list instead).
+        candidate_keys = sorted(durations.keys())
 
         if not (0 <= self.which_process < self.total_processes):
             self.logger.warning(
@@ -444,10 +365,10 @@ class NosePicker(Plugin):
             # so _should_run() falls back to hash-based selection for this run.
             return
         self._assigned_files = frozenset(bins[self.which_process])
-        self._all_candidate_keys = frozenset(candidate_keys)
+        self._known_keys = frozenset(candidate_keys)
         self.logger.info(
             'nose-picker: --file-durations bin-packing active; process %d/%d '
-            'assigned %d of %d discovered files, totalling %.1fs (all bin '
+            'assigned %d of %d known files, totalling %.1fs (all bin '
             'totals: %s)',
             self.which_process, self.total_processes,
             len(bins[self.which_process]), len(candidate_keys),
@@ -465,16 +386,16 @@ class NosePicker(Plugin):
         if self.enabled:
             if self._assigned_files is not None:
                 key = _relative_key(name)
-                if key in self._all_candidate_keys:
+                if key in self._known_keys:
+                    self._known_hits += 1
                     if key in self._assigned_files:
                         return None
                     return False
-                # This file exists (nose is asking about it) but our own
-                # upfront walk didn't enumerate it -- e.g. it was added after
-                # configure() ran, or our reimplementation of nose's
-                # discovery conventions missed a case. Fall back to the hash
-                # for this one file so it still runs in exactly one shard
-                # instead of silently vanishing from all of them.
+                # nose is visiting a file this run's durations table doesn't know about (new
+                # since the table was last refreshed, or the table doesn't cover it for any
+                # other reason). Fall back to the hash for this one file so it still runs in
+                # exactly one shard rather than vanishing from all of them.
+                self._unknown_hits += 1
                 return self._hash_should_run(name)
             return self._hash_should_run(name)
 
@@ -485,3 +406,21 @@ class NosePicker(Plugin):
         if hashed_value == self.which_process:
             return None
         return False
+
+    def report(self, stream):
+        """Log a one-time staleness summary once collection is complete, since (unlike an
+        earlier version of this feature) nose-picker no longer has an upfront full candidate
+        list to compare the durations table against -- it only learns "known" vs "unknown" as
+        nose's own real walk visits each file live. See module docstring for why.
+        """
+        total_hits = self._known_hits + self._unknown_hits
+        if self._assigned_files is not None and total_hits and self._unknown_hits:
+            unknown_fraction = self._unknown_hits / float(total_hits)
+            if unknown_fraction > 0.30:
+                self.logger.warning(
+                    'nose-picker: %d/%d files nose visited this run (%.0f%%) had no entry '
+                    'in the --file-durations table and fell back to hash-based selection '
+                    'individually; the durations cache may be stale.',
+                    self._unknown_hits, total_hits, unknown_fraction * 100.0,
+                )
+        return None

--- a/src/picker/nose_plugin.py
+++ b/src/picker/nose_plugin.py
@@ -146,10 +146,18 @@ def discover_candidate_files(root):
     complete candidate set that --which-process/--total-processes selection
     has always operated over one file at a time, without ever seeing the
     full list.
+
+    Dedupes by os.path.realpath() at both directory and file granularity, so
+    a symlink (a symlinked directory anywhere on the path, or a direct
+    symlink to a file) can never produce two separate entries for what's
+    really the same underlying file -- exactly the same realpath-based
+    identity hash_filename()/_relative_key() already use elsewhere in this
+    module, applied here too so callers never see duplicate candidates.
     '''
     root = os.path.realpath(root)
     candidates = []
     visited_dirs = set()
+    visited_files = set()
 
     def _walk(path):
         real = os.path.realpath(path)
@@ -166,6 +174,10 @@ def discover_candidate_files(root):
             entry_path = os.path.join(path, entry)
             if os.path.isfile(entry_path):
                 if _wants_file(entry, entry_path):
+                    real_file = os.path.realpath(entry_path)
+                    if real_file in visited_files:
+                        continue
+                    visited_files.add(real_file)
                     candidates.append(entry_path)
             elif os.path.isdir(entry_path):
                 if entry.startswith('_'):
@@ -402,6 +414,16 @@ class NosePicker(Plugin):
         if durations is None:
             return
 
+        # discover_candidate_files() already dedupes by os.path.realpath() at both directory and
+        # file granularity (see its docstring), so a symlink and its target can never appear as
+        # two separate entries here -- each candidate_keys entry (itself realpath-derived, via
+        # _relative_key()) is guaranteed unique. That invariant matters: without it,
+        # _bin_pack_files could place two occurrences of what's really one physical file into
+        # different bins, and two shards would each believe they own it and both run it. Legacy
+        # hash mode never had this failure mode (hash_filename() is realpath-based too, so a
+        # symlink and its target always hash identically and land on one shard together) --
+        # duration mode needs to preserve that same guarantee itself, which is what
+        # discover_candidate_files()'s dedup is for.
         candidate_paths = discover_candidate_files(os.getcwd())
         candidate_keys = [_relative_key(path) for path in candidate_paths]
 

--- a/src/picker/nose_plugin.py
+++ b/src/picker/nose_plugin.py
@@ -34,6 +34,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import site
 
 from nose.plugins import Plugin
@@ -160,16 +161,22 @@ def _load_durations_file(path, logger):
             parsed = float(value)
         except (TypeError, ValueError):
             continue
-        if not _is_finite(parsed):
+        if not _is_valid_duration(parsed):
             # Python's json module accepts bare NaN/Infinity/-Infinity literals by default (a
             # non-standard extension), so a corrupt or hand-edited durations file can produce one
             # of these here even though float(value) "succeeded". A NaN weight breaks every
             # comparison downstream (NaN is never <, >, or == anything, including itself) --
             # _bin_pack_files' own bail-out guard and its LPT tie-break both rely on ordinary
             # float comparisons behaving normally, so silently admitting a NaN/Infinity here would
-            # reintroduce a single-shard collapse through the back door. Treat it exactly like any
-            # other value that failed to parse: drop the entry, fall back to the median for that
-            # key at bin-packing time.
+            # reintroduce a single-shard collapse through the back door. A negative value is never
+            # physically meaningful for a measured runtime either (nothing stops a corrupt file or
+            # a buggy upstream aggregator from producing one), and is just as dangerous in a
+            # different way: it *lowers* whichever bin it's added to, so the LPT loop keeps
+            # preferring that artificially-cheap bin for every subsequent placement and piles most
+            # of the suite onto it -- an imbalance bug, not a collapse, but just as much a
+            # regression from hash-modulo. Treat all of these exactly like any other value that
+            # failed to parse: drop the entry, fall back to the median for that key at
+            # bin-packing time.
             continue
         durations[key] = parsed
     return durations
@@ -180,6 +187,15 @@ def _is_finite(value):
     equal itself; +-inf are the only floats equal to float('inf')/float('-inf').
     '''
     return value == value and value not in (float('inf'), float('-inf'))
+
+
+def _is_valid_duration(value):
+    '''A valid measured duration is finite and non-negative (see _is_finite for why non-finite
+    values are rejected; a negative value is never physically meaningful for a measured runtime,
+    and skews LPT bin-packing by artificially lowering whichever bin it lands in -- see callers).
+    Zero is valid (a trivial/empty test file can legitimately take ~0 seconds).
+    '''
+    return _is_finite(value) and value >= 0.0
 
 
 def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_threshold=0.30):
@@ -207,17 +223,19 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
     why that specific case can't be bin-packed.
     '''
     # Defensively re-sanitize here too, even though _load_durations_file() already filters
-    # non-finite values on the normal production path: this function is independently
-    # unit-tested and could be called with a hand-built `durations` dict from anywhere. A NaN
-    # weight is uniquely dangerous because NaN is never <, >, or == anything (including itself),
-    # which breaks both the bail-out guard below (`max()` over a list containing NaN is
-    # order-dependent and can silently return NaN, making `NaN <= 0.0` evaluate False) and the
-    # LPT tie-break's bin_totals comparisons (a bin total poisoned by NaN can never again compare
-    # as strictly less than another bin, effectively freezing every remaining candidate onto a
-    # single bin) -- treating a non-finite entry as though the key were simply absent from
-    # `durations` (falls back to the median, like any other missing/unparseable value) closes
-    # both of those off at the source instead of trying to special-case NaN/Infinity downstream.
-    durations = dict((k, v) for k, v in durations.items() if _is_finite(v))
+    # invalid values on the normal production path: this function is independently unit-tested
+    # and could be called with a hand-built `durations` dict from anywhere. A NaN weight is
+    # uniquely dangerous because NaN is never <, >, or == anything (including itself), which
+    # breaks both the bail-out guard below (`max()` over a list containing NaN is order-dependent
+    # and can silently return NaN, making `NaN <= 0.0` evaluate False) and the LPT tie-break's
+    # bin_totals comparisons (a bin total poisoned by NaN can never again compare as strictly less
+    # than another bin, effectively freezing every remaining candidate onto a single bin). A
+    # negative weight is dangerous in a different way -- it lowers whichever bin it's added to,
+    # so the LPT loop keeps preferring that artificially-cheap bin for every later placement,
+    # piling most of the suite onto it. Treating an invalid entry as though the key were simply
+    # absent from `durations` (falls back to the median, like any other missing/unparseable
+    # value) closes off both failure modes at the source instead of special-casing them downstream.
+    durations = dict((k, v) for k, v in durations.items() if _is_valid_duration(v))
     known_values = [durations[k] for k in candidate_keys if k in durations]
 
     if not known_values or max(known_values) <= 0.0:
@@ -273,6 +291,35 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
         bin_files[target].append(key)
 
     return bin_files, bin_totals
+
+
+# nose's own Selector.wantFile calls every registered plugin's wantFile() hook for *every*
+# non-ignored .py file it walks (ordinary source modules, __init__.py, helpers -- not just files
+# that look like tests), regardless of whether that file also matches nose's own testMatch
+# convention; testMatch only decides nose's *default* fallback answer when every plugin abstains
+# (returns None). NosePicker's own selection logic (_should_run below) already handles this
+# correctly by design -- returning None (not an explicit "yes") whenever hash/duration-membership
+# says "this shard wants it" defers to nose's own testMatch-based default for the final verdict,
+# exactly as the original 0.5.7 behavior always has, so no non-test file is ever incorrectly
+# selected as a result.
+#
+# But report()'s known-vs-unknown staleness counters (see NosePicker.report below) would still be
+# swamped by every one of those non-test wantFile() calls if they counted all of them equally --
+# in a large codebase, ordinary source files can easily outnumber real test files 10-100x, so the
+# "% of files unknown to the durations table" metric would be dominated by files that were never
+# going to be in that table anyway (it only ever contains real test-file keys, populated from
+# actual junit output), making the staleness warning fire constantly regardless of whether the
+# table is actually fresh. _looks_testlike is a best-effort, reporting-only heuristic (nose's own
+# default testMatch regex, used here purely to decide what's worth counting) to filter that noise
+# out. It is deliberately NOT used for any selection decision -- if it occasionally disagrees with
+# nose's real testMatch verdict, the only consequence is a slightly noisier or quieter staleness
+# warning, not a correctness bug, unlike the discovery-convention reimplementation this PR
+# removed (see the module docstring above the bin-packing section).
+_TESTLIKE_NAME_RE = re.compile(r'(?:^|[\b_\.%s-])[Tt]est' % os.sep)
+
+
+def _looks_testlike(basename):
+    return bool(_TESTLIKE_NAME_RE.search(basename))
 
 
 class NosePicker(Plugin):
@@ -417,8 +464,18 @@ class NosePicker(Plugin):
         if self.enabled:
             if self._assigned_files is not None:
                 key = _relative_key(name)
-                if key in self._known_keys:
-                    self._known_hits += 1
+                known = key in self._known_keys
+                # Only count staleness hits for files that at least look like tests by name --
+                # see _looks_testlike's comment for why (nose calls wantFile() for every .py file,
+                # not just test-like ones, and this metric would otherwise be swamped by ordinary
+                # source files that were never going to be in the durations table anyway). This
+                # never affects the actual selection logic below, only what report() counts.
+                if _looks_testlike(os.path.basename(name)):
+                    if known:
+                        self._known_hits += 1
+                    else:
+                        self._unknown_hits += 1
+                if known:
                     if key in self._assigned_files:
                         return None
                     return False
@@ -426,7 +483,6 @@ class NosePicker(Plugin):
                 # since the table was last refreshed, or the table doesn't cover it for any
                 # other reason). Fall back to the hash for this one file so it still runs in
                 # exactly one shard rather than vanishing from all of them.
-                self._unknown_hits += 1
                 return self._hash_should_run(name)
             return self._hash_should_run(name)
 

--- a/src/picker/nose_plugin.py
+++ b/src/picker/nose_plugin.py
@@ -245,8 +245,30 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
     file can never be split across bins, so no bin-packing scheme built on
     top of nose's per-file wantFile() hook can fully even out wall-clock time
     if one file dominates -- see the PR description / README for this ceiling.
+
+    Returns (bin_files, bin_totals), or (None, None) if there is no usable
+    timing signal at all for `candidate_keys` (durations table doesn't cover
+    any of them, or every covered value is <= 0) -- see the guard below for
+    why that specific case can't be bin-packed.
     '''
     known_values = [durations[k] for k in candidate_keys if k in durations]
+
+    if not known_values or max(known_values) <= 0.0:
+        # No usable timing signal at all for this candidate set -- every file
+        # would get weight 0.0 (median of nothing, or median of all-zeros),
+        # which collapses the whole LPT loop onto bin 0: adding 0.0 never
+        # changes bin_totals, so bin_totals.index(min(bin_totals)) never
+        # advances past index 0 and the entire suite lands on one shard,
+        # actively worse than the hash-modulo behavior this is meant to
+        # improve on. Signal "can't bin-pack" to the caller so it falls back
+        # to classic hash-based selection instead.
+        logger.warning(
+            'nose-picker: no usable durations found among %d discovered test '
+            'files; falling back to hash-based file selection.',
+            len(candidate_keys),
+        )
+        return None, None
+
     fallback_weight = _median(known_values)
     missing = [k for k in candidate_keys if k not in durations]
 
@@ -264,10 +286,23 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
     ordered = sorted(candidate_keys, key=lambda key: (-weights[key], key))
 
     bin_totals = [0.0] * total_processes
+    bin_counts = [0] * total_processes
     bin_files = [[] for _ in range(total_processes)]
     for key in ordered:
-        target = bin_totals.index(min(bin_totals))
+        # Break ties on bin total by which bin currently holds the fewest files, not by raw bin
+        # index. A plain `bin_totals.index(min(bin_totals))` looks safe but silently clumps any
+        # run of *equal-weight* files onto a single bin whenever the increment doesn't strictly
+        # grow past the tied group -- which is exactly what happens for weight 0.0 (adding 0.0
+        # never changes a bin's total, so it stays tied-for-minimum forever, and `.index(...)`
+        # always returns the same one). This isn't just the all-zero/no-signal case guarded above:
+        # a perfectly healthy table can still legitimately have a handful of individual files at
+        # exactly 0.0 (e.g. trivial/empty test files) mixed in with real positive durations, and
+        # those would clump the same way without this. Tracking file counts per bin and using them
+        # as the tie-break makes any tied group -- all-zero, partially-zero, or equal-nonzero --
+        # round-robin across bins instead.
+        target = min(range(total_processes), key=lambda i: (bin_totals[i], bin_counts[i]))
         bin_totals[target] += weights[key]
+        bin_counts[target] += 1
         bin_files[target].append(key)
 
     return bin_files, bin_totals
@@ -381,6 +416,11 @@ class NosePicker(Plugin):
         bins, totals = _bin_pack_files(
             candidate_keys, durations, self.total_processes, self.logger,
         )
+        if bins is None:
+            # No usable timing signal at all (see _bin_pack_files) -- it already
+            # logged why. self._assigned_files is still None from configure(),
+            # so _should_run() falls back to hash-based selection for this run.
+            return
         self._assigned_files = frozenset(bins[self.which_process])
         self._all_candidate_keys = frozenset(candidate_keys)
         self.logger.info(

--- a/src/picker/nose_plugin.py
+++ b/src/picker/nose_plugin.py
@@ -157,10 +157,29 @@ def _load_durations_file(path, logger):
     durations = {}
     for key, value in raw.items():
         try:
-            durations[key] = float(value)
+            parsed = float(value)
         except (TypeError, ValueError):
             continue
+        if not _is_finite(parsed):
+            # Python's json module accepts bare NaN/Infinity/-Infinity literals by default (a
+            # non-standard extension), so a corrupt or hand-edited durations file can produce one
+            # of these here even though float(value) "succeeded". A NaN weight breaks every
+            # comparison downstream (NaN is never <, >, or == anything, including itself) --
+            # _bin_pack_files' own bail-out guard and its LPT tie-break both rely on ordinary
+            # float comparisons behaving normally, so silently admitting a NaN/Infinity here would
+            # reintroduce a single-shard collapse through the back door. Treat it exactly like any
+            # other value that failed to parse: drop the entry, fall back to the median for that
+            # key at bin-packing time.
+            continue
+        durations[key] = parsed
     return durations
+
+
+def _is_finite(value):
+    '''No math.isfinite on Python 2.7 (added in Python 3.2). NaN is the only float that doesn't
+    equal itself; +-inf are the only floats equal to float('inf')/float('-inf').
+    '''
+    return value == value and value not in (float('inf'), float('-inf'))
 
 
 def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_threshold=0.30):
@@ -187,6 +206,18 @@ def _bin_pack_files(candidate_keys, durations, total_processes, logger, stale_th
     any of them, or every covered value is <= 0) -- see the guard below for
     why that specific case can't be bin-packed.
     '''
+    # Defensively re-sanitize here too, even though _load_durations_file() already filters
+    # non-finite values on the normal production path: this function is independently
+    # unit-tested and could be called with a hand-built `durations` dict from anywhere. A NaN
+    # weight is uniquely dangerous because NaN is never <, >, or == anything (including itself),
+    # which breaks both the bail-out guard below (`max()` over a list containing NaN is
+    # order-dependent and can silently return NaN, making `NaN <= 0.0` evaluate False) and the
+    # LPT tie-break's bin_totals comparisons (a bin total poisoned by NaN can never again compare
+    # as strictly less than another bin, effectively freezing every remaining candidate onto a
+    # single bin) -- treating a non-finite entry as though the key were simply absent from
+    # `durations` (falls back to the median, like any other missing/unparseable value) closes
+    # both of those off at the source instead of trying to special-case NaN/Infinity downstream.
+    durations = dict((k, v) for k, v in durations.items() if _is_finite(v))
     known_values = [durations[k] for k in candidate_keys if k in durations]
 
     if not known_values or max(known_values) <= 0.0:

--- a/tests/test_nose_plugin.py
+++ b/tests/test_nose_plugin.py
@@ -223,6 +223,91 @@ class DiscoverCandidateFilesTest(unittest.TestCase):
         ]))
 
 
+class NestedNonPackageDirectoryTest(unittest.TestCase):
+    """Regression coverage for a matching-semantics question raised (and empirically settled)
+    during review: does nose 1.3.7 apply testMatch against a directory's basename only, or
+    against the full path (which would let an already-matching ancestor segment like `tests/`
+    "cover" a non-matching, non-package child like `tests/unit/`)?
+
+    Verified directly against real nose 1.3.7 (not just by reading its source): a
+    `tests/unit/test_foo.py` layout where `unit` has no `__init__.py` and doesn't itself contain
+    "test" produces **zero** collected tests under plain `nosetests -v` -- nose's own
+    `Selector.wantDirectory` only ever inspects `os.path.basename(dirname)`
+    (`tail = op_basename(dirname); ... self.matches(tail)`), so a matching ancestor does *not*
+    rescue a non-matching, non-package child directory. This module's `_wants_directory` mirrors
+    that (basename-only) on purpose -- switching it to check the full path, as the regex's
+    inclusion of `os.sep` might suggest at a glance, would make discovery *more* permissive than
+    real nose and start bin-packing files nose itself would never actually collect.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def _make(self, rel_parts):
+        full = os.path.join(self.tmp, *rel_parts)
+        d = os.path.dirname(full)
+        if not os.path.isdir(d):
+            os.makedirs(d)
+        open(full, 'w').close()
+
+    def test_non_package_child_of_a_matching_dir_is_not_discovered(self):
+        # `tests` matches testMatch on its own basename; `unit` does not, and isn't a package.
+        self._make(['tests/unit/test_should_not_appear.py'])
+        candidates = discover_candidate_files(self.tmp)
+        self.assertEqual(candidates, [])
+
+    def test_package_child_of_a_matching_dir_is_discovered(self):
+        # Same layout, but `unit` (and `tests`) are now proper packages -- ispackage() alone is
+        # enough to recurse regardless of the directory's own name, in both real nose and here.
+        self._make(['tests/__init__.py'])
+        self._make(['tests/unit/__init__.py'])
+        self._make(['tests/unit/test_should_appear.py'])
+        candidates = discover_candidate_files(self.tmp)
+        rels = sorted(_relative_key(c, cwd=self.tmp) for c in candidates)
+        self.assertEqual(rels, ['/tests/unit/test_should_appear.py'])
+
+
+class SymlinkDedupTest(unittest.TestCase):
+    """Regression coverage: a symlink to a test file must not produce a second candidate for
+    what's really the same physical file. discover_candidate_files() dedupes by
+    os.path.realpath() at file granularity (mirroring the same realpath-based identity
+    hash_filename()/_relative_key() already use, and the same dedup discover_candidate_files()
+    already did for directories to guard against symlink cycles) -- without it, _bin_pack_files
+    could place the real file and its symlink into two different bins, and two shards would each
+    believe they own the file and both run it, unlike legacy hash mode (realpath-based, so a
+    symlink and its target always hash identically and land on one shard together).
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def test_symlinked_file_does_not_duplicate_candidate(self):
+        real_path = os.path.join(self.tmp, 'test_real.py')
+        open(real_path, 'w').close()
+        symlink_path = os.path.join(self.tmp, 'test_symlink.py')
+        os.symlink(real_path, symlink_path)
+
+        candidates = discover_candidate_files(self.tmp)
+        # Two directory entries exist (test_real.py, test_symlink.py), but they're the same
+        # underlying file -- exactly one candidate, not two.
+        self.assertEqual(len(candidates), 1)
+
+    def test_symlinked_directory_does_not_duplicate_candidates(self):
+        real_dir = os.path.join(self.tmp, 'real_tests')
+        os.makedirs(real_dir)
+        open(os.path.join(real_dir, 'test_a.py'), 'w').close()
+        os.symlink(real_dir, os.path.join(self.tmp, 'test_symlinked_dir'))
+
+        candidates = discover_candidate_files(self.tmp)
+        self.assertEqual(len(candidates), 1)
+
+
 class FullShardCoverageTest(unittest.TestCase):
     """End-to-end style checks: across every shard 0..N-1, every discovered
     file must be claimed by exactly one shard -- in legacy hash mode, in

--- a/tests/test_nose_plugin.py
+++ b/tests/test_nose_plugin.py
@@ -118,11 +118,58 @@ class BinPackFilesTest(unittest.TestCase):
         self.assertEqual(sorted(assigned), sorted(keys))
 
     def test_deterministic_tie_break_by_path(self):
-        durations = {}
+        # One known value so every file (including the two unknowns, which fall back to the
+        # median of known values) ties at the same weight -- exercises path tie-breaking without
+        # tripping the all-unknown collapse guard covered separately below.
+        durations = {'/z.py': 5.0}
         keys = ['/z.py', '/a.py', '/m.py']
         bins1, _ = _bin_pack_files(keys, durations, 3, self.logger)
         bins2, _ = _bin_pack_files(list(reversed(keys)), durations, 3, self.logger)
         self.assertEqual(bins1, bins2)
+
+    def test_no_usable_durations_signals_fallback_instead_of_collapsing(self):
+        # Regression test: previously, when no candidate file had a known duration (or all known
+        # durations were <= 0), every file got weight 0.0, and the LPT loop's
+        # `bin_totals.index(min(bin_totals))` never advanced past index 0 (adding 0.0 never
+        # changes bin_totals) -- the entire suite silently collapsed onto a single shard, with
+        # every other shard getting nothing. _bin_pack_files must now signal "can't bin-pack" by
+        # returning (None, None) instead, so the caller falls back to hash-based selection.
+        keys = ['/a.py', '/b.py', '/c.py']
+
+        bins, totals = _bin_pack_files(keys, {}, 3, self.logger)
+        self.assertIsNone(bins)
+        self.assertIsNone(totals)
+
+        all_zero_durations = dict((key, 0.0) for key in keys)
+        bins, totals = _bin_pack_files(keys, all_zero_durations, 3, self.logger)
+        self.assertIsNone(bins)
+        self.assertIsNone(totals)
+
+    def test_partial_zero_weight_files_round_robin_instead_of_clumping(self):
+        # Narrower, separate regression case from the total-collapse one above: a perfectly
+        # healthy table (real positive durations exist, so the bail-out guard doesn't fire) can
+        # still legitimately have a handful of individual files measured at exactly 0.0 (trivial
+        # or empty test files). LPT sorts heaviest-first, so all the 0.0-weight files end up
+        # adjacent at the tail of `ordered`; a naive `bin_totals.index(min(bin_totals))` tie-break
+        # would clump every one of them onto whichever single bin happened to be minimum when the
+        # zero-weight run started, since adding 0.0 never changes that bin's total. They must
+        # instead round-robin, by file count, across whichever bins are currently tied-minimum.
+        zero_weight_files = ['/zero_%d.py' % i for i in range(6)]
+        durations = dict((f, 0.0) for f in zero_weight_files)
+        durations['/big.py'] = 100.0
+        keys = ['/big.py'] + zero_weight_files
+        bins, totals = _bin_pack_files(keys, durations, 3, self.logger)
+
+        self.assertEqual(sorted(sum(bins, [])), sorted(keys))
+        zero_weight_bin_sizes = sorted(
+            sum(1 for f in b if f in zero_weight_files) for b in bins
+        )
+        # /big.py's bin is left at total=100 after the first placement, so it's correctly never
+        # tied-minimum again -- the 6 zero-weight files round-robin evenly across the *other* two
+        # bins only (3/3), rather than all 6 clumping onto whichever single bin the old
+        # `bin_totals.index(min(...))` tie-break happened to pick first (the bug this regression
+        # test covers would have produced something like [0, 0, 6] here).
+        self.assertEqual(zero_weight_bin_sizes, [0, 3, 3])
 
 
 class HashFilenameBackwardCompatTest(unittest.TestCase):
@@ -244,6 +291,28 @@ class FullShardCoverageTest(unittest.TestCase):
             json.dump({self.expected_keys[0]: 42.0}, fh)
         assignment = self._run_all_shards(3, file_durations=path)
         self._assert_bijection(assignment)
+
+    def test_duration_mode_wholly_unmatched_table_falls_back_identically_to_legacy(self):
+        # Regression coverage for the all-unknown-durations collapse bug: a durations table that
+        # doesn't overlap the discovered candidate set at all (e.g. every path in it belongs to
+        # files that no longer exist) must fall back to hash-based selection -- not silently
+        # collapse the whole suite onto shard 0.
+        path = os.path.join(self.tmp, 'wholly_unmatched.json')
+        with open(path, 'w') as fh:
+            json.dump({'/this/file/does/not/exist.py': 123.0}, fh)
+        legacy = self._run_all_shards(3, file_durations=None)
+        fallback = self._run_all_shards(3, file_durations=path)
+        self._assert_bijection(fallback)
+        self.assertEqual(legacy, fallback)
+
+    def test_duration_mode_all_zero_durations_falls_back_identically_to_legacy(self):
+        path = os.path.join(self.tmp, 'all_zero.json')
+        with open(path, 'w') as fh:
+            json.dump(dict((k, 0.0) for k in self.expected_keys), fh)
+        legacy = self._run_all_shards(3, file_durations=None)
+        fallback = self._run_all_shards(3, file_durations=path)
+        self._assert_bijection(fallback)
+        self.assertEqual(legacy, fallback)
 
     def test_missing_durations_file_falls_back_identically_to_legacy(self):
         legacy = self._run_all_shards(3, file_durations=None)

--- a/tests/test_nose_plugin.py
+++ b/tests/test_nose_plugin.py
@@ -14,7 +14,6 @@ from picker.nose_plugin import (
     _load_durations_file,
     _median,
     _relative_key,
-    discover_candidate_files,
     hash_filename,
 )
 
@@ -43,6 +42,19 @@ def _make_options(which_process, total_processes, file_durations=None):
         'futz_with_django': False,
         'file_durations': file_durations,
     })
+
+
+class _ListHandler(logging.Handler):
+    """Captures emitted records' messages so tests can assert on logger.warning() calls
+    without depending on stderr/stdout capture.
+    """
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
 
 
 class MedianTest(unittest.TestCase):
@@ -188,151 +200,31 @@ class HashFilenameBackwardCompatTest(unittest.TestCase):
         self.assertEqual(hash_filename(path), hash_filename('test_foo.py'))
 
 
-class DiscoverCandidateFilesTest(unittest.TestCase):
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self._make(['pkg/__init__.py'])
-        self._make(['pkg/test_foo.py'])
-        self._make(['pkg/bar_test.py'])
-        self._make(['pkg/helpers.py'])  # not test-like, must be excluded
-        self._make(['pkg/sub/__init__.py'])
-        self._make(['pkg/sub/test_deep.py'])
-        self._make(['lib/test_in_lib.py'])  # nose's srcDirs special case
-        self._make(['notpkg/test_should_not_appear.py'])  # non-package, non-testMatch dir
-        self._make(['_hidden/test_should_not_appear2.py'])  # leading underscore dir
-        self._make(['.dotdir/test_should_not_appear3.py'])  # leading dot dir
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp)
-
-    def _make(self, rel_parts):
-        full = os.path.join(self.tmp, *rel_parts)
-        d = os.path.dirname(full)
-        if not os.path.isdir(d):
-            os.makedirs(d)
-        open(full, 'w').close()
-
-    def test_matches_nose_default_conventions(self):
-        candidates = discover_candidate_files(self.tmp)
-        rels = sorted(_relative_key(c, cwd=self.tmp) for c in candidates)
-        self.assertEqual(rels, sorted([
-            '/lib/test_in_lib.py',
-            '/pkg/bar_test.py',
-            '/pkg/sub/test_deep.py',
-            '/pkg/test_foo.py',
-        ]))
-
-
-class NestedNonPackageDirectoryTest(unittest.TestCase):
-    """Regression coverage for a matching-semantics question raised (and empirically settled)
-    during review: does nose 1.3.7 apply testMatch against a directory's basename only, or
-    against the full path (which would let an already-matching ancestor segment like `tests/`
-    "cover" a non-matching, non-package child like `tests/unit/`)?
-
-    Verified directly against real nose 1.3.7 (not just by reading its source): a
-    `tests/unit/test_foo.py` layout where `unit` has no `__init__.py` and doesn't itself contain
-    "test" produces **zero** collected tests under plain `nosetests -v` -- nose's own
-    `Selector.wantDirectory` only ever inspects `os.path.basename(dirname)`
-    (`tail = op_basename(dirname); ... self.matches(tail)`), so a matching ancestor does *not*
-    rescue a non-matching, non-package child directory. This module's `_wants_directory` mirrors
-    that (basename-only) on purpose -- switching it to check the full path, as the regex's
-    inclusion of `os.sep` might suggest at a glance, would make discovery *more* permissive than
-    real nose and start bin-packing files nose itself would never actually collect.
-    """
-
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp)
-
-    def _make(self, rel_parts):
-        full = os.path.join(self.tmp, *rel_parts)
-        d = os.path.dirname(full)
-        if not os.path.isdir(d):
-            os.makedirs(d)
-        open(full, 'w').close()
-
-    def test_non_package_child_of_a_matching_dir_is_not_discovered(self):
-        # `tests` matches testMatch on its own basename; `unit` does not, and isn't a package.
-        self._make(['tests/unit/test_should_not_appear.py'])
-        candidates = discover_candidate_files(self.tmp)
-        self.assertEqual(candidates, [])
-
-    def test_package_child_of_a_matching_dir_is_discovered(self):
-        # Same layout, but `unit` (and `tests`) are now proper packages -- ispackage() alone is
-        # enough to recurse regardless of the directory's own name, in both real nose and here.
-        self._make(['tests/__init__.py'])
-        self._make(['tests/unit/__init__.py'])
-        self._make(['tests/unit/test_should_appear.py'])
-        candidates = discover_candidate_files(self.tmp)
-        rels = sorted(_relative_key(c, cwd=self.tmp) for c in candidates)
-        self.assertEqual(rels, ['/tests/unit/test_should_appear.py'])
-
-
-class SymlinkDedupTest(unittest.TestCase):
-    """Regression coverage: a symlink to a test file must not produce a second candidate for
-    what's really the same physical file. discover_candidate_files() dedupes by
-    os.path.realpath() at file granularity (mirroring the same realpath-based identity
-    hash_filename()/_relative_key() already use, and the same dedup discover_candidate_files()
-    already did for directories to guard against symlink cycles) -- without it, _bin_pack_files
-    could place the real file and its symlink into two different bins, and two shards would each
-    believe they own the file and both run it, unlike legacy hash mode (realpath-based, so a
-    symlink and its target always hash identically and land on one shard together).
-    """
-
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp)
-
-    def test_symlinked_file_does_not_duplicate_candidate(self):
-        real_path = os.path.join(self.tmp, 'test_real.py')
-        open(real_path, 'w').close()
-        symlink_path = os.path.join(self.tmp, 'test_symlink.py')
-        os.symlink(real_path, symlink_path)
-
-        candidates = discover_candidate_files(self.tmp)
-        # Two directory entries exist (test_real.py, test_symlink.py), but they're the same
-        # underlying file -- exactly one candidate, not two.
-        self.assertEqual(len(candidates), 1)
-
-    def test_symlinked_directory_does_not_duplicate_candidates(self):
-        real_dir = os.path.join(self.tmp, 'real_tests')
-        os.makedirs(real_dir)
-        open(os.path.join(real_dir, 'test_a.py'), 'w').close()
-        os.symlink(real_dir, os.path.join(self.tmp, 'test_symlinked_dir'))
-
-        candidates = discover_candidate_files(self.tmp)
-        self.assertEqual(len(candidates), 1)
-
-
 class FullShardCoverageTest(unittest.TestCase):
-    """End-to-end style checks: across every shard 0..N-1, every discovered
-    file must be claimed by exactly one shard -- in legacy hash mode, in
-    duration mode, and in every fallback path duration mode can take.
+    """End-to-end style checks: across every shard 0..N-1, every file nose's real walk visits
+    this run must be claimed by exactly one shard -- in legacy hash mode, in duration mode, and
+    in every fallback path duration mode can take.
+
+    nose-picker does not do its own filesystem walk (see the module docstring in
+    nose_plugin.py for why): the candidate set for bin-packing is just the --file-durations
+    table's own keys, and nose's real Loader/Selector keeps calling wantFile() one file at a
+    time exactly as it always did. So "files nose visits this run" here is simply a fixed list
+    of paths fed directly into _should_run(), one at a time, mirroring that -- there's no
+    filesystem convention to fake, and the files don't even need to exist on disk (this module's
+    path handling is pure os.path.realpath()-based string manipulation).
     """
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.old_cwd = os.getcwd()
-        for rel in [
-            'pkg/__init__.py', 'pkg/test_foo.py', 'pkg/bar_test.py',
-            'pkg/helpers.py', 'pkg/sub/__init__.py', 'pkg/sub/test_deep.py',
-            'lib/test_in_lib.py',
-        ]:
-            full = os.path.join(self.tmp, rel)
-            d = os.path.dirname(full)
-            if not os.path.isdir(d):
-                os.makedirs(d)
-            open(full, 'w').close()
         os.chdir(self.tmp)
-        self.expected_keys = sorted(
-            _relative_key(c, cwd=self.tmp)
-            for c in discover_candidate_files(self.tmp)
-        )
-        self.assertEqual(len(self.expected_keys), 4)
+        self.files_this_run = [
+            os.path.join(self.tmp, 'pkg', 'test_foo.py'),
+            os.path.join(self.tmp, 'pkg', 'bar_test.py'),
+            os.path.join(self.tmp, 'pkg', 'sub', 'test_deep.py'),
+            os.path.join(self.tmp, 'lib', 'test_in_lib.py'),
+        ]
+        self.expected_keys = sorted(_relative_key(f, cwd=self.tmp) for f in self.files_this_run)
 
     def tearDown(self):
         os.chdir(self.old_cwd)
@@ -346,15 +238,16 @@ class FullShardCoverageTest(unittest.TestCase):
                 _make_options(which, total_processes, file_durations),
                 _FakeConfig(),
             )
-            for full_path in discover_candidate_files(self.tmp):
+            for full_path in self.files_this_run:
                 key = _relative_key(full_path, cwd=self.tmp)
                 wanted = plugin._should_run(full_path) is None
                 if wanted:
                     assignment.setdefault(key, []).append(which)
         return assignment
 
-    def _assert_bijection(self, assignment):
-        self.assertEqual(sorted(assignment.keys()), self.expected_keys)
+    def _assert_bijection(self, assignment, expected_keys=None):
+        expected_keys = self.expected_keys if expected_keys is None else expected_keys
+        self.assertEqual(sorted(assignment.keys()), sorted(expected_keys))
         for key, shards in assignment.items():
             self.assertEqual(len(shards), 1, 'file %s claimed by %r' % (key, shards))
 
@@ -370,18 +263,23 @@ class FullShardCoverageTest(unittest.TestCase):
         assignment = self._run_all_shards(3, file_durations=path)
         self._assert_bijection(assignment)
 
-    def test_duration_mode_stale_table_still_covers_everything(self):
+    def test_duration_mode_partially_known_still_covers_everything(self):
+        # Half the files this run visits are in the durations table (bin-packed), half are new
+        # (not in the table, e.g. added since it was last refreshed) and fall back to the hash
+        # individually. Every file must still land in exactly one shard either way.
+        known_keys = self.expected_keys[:2]
+        durations = dict((k, random.uniform(1, 100)) for k in known_keys)
         path = os.path.join(self.tmp, 'partial.json')
         with open(path, 'w') as fh:
-            json.dump({self.expected_keys[0]: 42.0}, fh)
+            json.dump(durations, fh)
         assignment = self._run_all_shards(3, file_durations=path)
         self._assert_bijection(assignment)
 
     def test_duration_mode_wholly_unmatched_table_falls_back_identically_to_legacy(self):
-        # Regression coverage for the all-unknown-durations collapse bug: a durations table that
-        # doesn't overlap the discovered candidate set at all (e.g. every path in it belongs to
-        # files that no longer exist) must fall back to hash-based selection -- not silently
-        # collapse the whole suite onto shard 0.
+        # A durations table that doesn't overlap the files visited this run at all (e.g. it only
+        # knows about files that no longer exist) means _should_run() treats every file visited
+        # this run as "unknown" and falls back to the hash for each -- byte-for-byte the same as
+        # legacy mode, not some degraded in-between state.
         path = os.path.join(self.tmp, 'wholly_unmatched.json')
         with open(path, 'w') as fh:
             json.dump({'/this/file/does/not/exist.py': 123.0}, fh)
@@ -411,6 +309,75 @@ class FullShardCoverageTest(unittest.TestCase):
         legacy = self._run_all_shards(3, file_durations=None)
         fallback = self._run_all_shards(3, file_durations=path)
         self.assertEqual(legacy, fallback)
+
+
+class ReportStalenessWarningTest(unittest.TestCase):
+    """The durations table is no longer compared against an upfront full candidate list (there
+    isn't one -- see module docstring), so staleness can only be observed live, as nose's real
+    walk visits each file one at a time. report() -- nose's standard end-of-run plugin hook --
+    logs a one-time summary warning if too large a fraction of *this run's actually-visited*
+    files fell back to hash-based selection individually.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmp)
+        self.logger_handler = _ListHandler()
+        self.plugin = NosePicker()
+        self.plugin.logger.addHandler(self.logger_handler)
+        self.plugin.logger.setLevel(logging.DEBUG)
+
+    def tearDown(self):
+        self.plugin.logger.removeHandler(self.logger_handler)
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tmp)
+
+    def _visit(self, *relnames):
+        for relname in relnames:
+            self.plugin._should_run(os.path.join(self.tmp, relname))
+
+    def test_mostly_unknown_files_this_run_warns_on_report(self):
+        durations_path = os.path.join(self.tmp, 'durations.json')
+        with open(durations_path, 'w') as fh:
+            json.dump({_relative_key(os.path.join(self.tmp, 'test_known.py'), cwd=self.tmp): 5.0}, fh)
+        self.plugin.configure(_make_options(0, 2, durations_path), _FakeConfig())
+
+        self._visit('test_known.py', 'test_new_a.py', 'test_new_b.py', 'test_new_c.py')
+        self.logger_handler.messages = []  # only care about what report() itself logs
+        self.plugin.report(None)
+
+        self.assertTrue(
+            any('durations cache may be stale' in msg for msg in self.logger_handler.messages),
+            self.logger_handler.messages,
+        )
+
+    def test_mostly_known_files_this_run_does_not_warn_on_report(self):
+        known_names = ['test_a.py', 'test_b.py', 'test_c.py', 'test_d.py']
+        durations = dict(
+            (_relative_key(os.path.join(self.tmp, name), cwd=self.tmp), 5.0)
+            for name in known_names
+        )
+        durations_path = os.path.join(self.tmp, 'durations.json')
+        with open(durations_path, 'w') as fh:
+            json.dump(durations, fh)
+        self.plugin.configure(_make_options(0, 2, durations_path), _FakeConfig())
+
+        self._visit(*known_names)
+        self.logger_handler.messages = []
+        self.plugin.report(None)
+
+        self.assertFalse(
+            any('durations cache may be stale' in msg for msg in self.logger_handler.messages),
+            self.logger_handler.messages,
+        )
+
+    def test_legacy_hash_mode_never_warns_on_report(self):
+        self.plugin.configure(_make_options(0, 2, None), _FakeConfig())
+        self._visit('test_a.py', 'test_b.py')
+        self.logger_handler.messages = []
+        self.plugin.report(None)
+        self.assertEqual(self.logger_handler.messages, [])
 
 
 if __name__ == '__main__':

--- a/tests/test_nose_plugin.py
+++ b/tests/test_nose_plugin.py
@@ -1,0 +1,263 @@
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+import random
+import shutil
+import tempfile
+import unittest
+
+from picker.nose_plugin import (
+    NosePicker,
+    _bin_pack_files,
+    _load_durations_file,
+    _median,
+    _relative_key,
+    discover_candidate_files,
+    hash_filename,
+)
+
+
+class _FakeOptions(object):
+    """Minimal stand-in for optparse.Values, good enough to drive
+    NosePicker.configure() the way nose's own OptionParser would.
+    """
+
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+    def __getattr__(self, item):
+        return None
+
+
+class _FakeConfig(object):
+    pass
+
+
+def _make_options(which_process, total_processes, file_durations=None):
+    return _FakeOptions(**{
+        'with-nose-picker': True,  # NosePicker.enableOpt is 'with-nose-picker', dash not underscore
+        'which_process': which_process,
+        'total_processes': total_processes,
+        'futz_with_django': False,
+        'file_durations': file_durations,
+    })
+
+
+class MedianTest(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(_median([]), 0.0)
+
+    def test_single(self):
+        self.assertEqual(_median([5]), 5.0)
+
+    def test_odd(self):
+        self.assertEqual(_median([3, 1, 2]), 2.0)
+
+    def test_even(self):
+        self.assertEqual(_median([4, 1, 3, 2]), 2.5)
+
+
+class LoadDurationsFileTest(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger('test.nose_picker')
+
+    def test_none_path(self):
+        self.assertIsNone(_load_durations_file(None, self.logger))
+
+    def test_missing_path(self):
+        self.assertIsNone(_load_durations_file('/no/such/file.json', self.logger))
+
+    def test_invalid_json(self):
+        fh = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+        fh.write(b'{not valid json')
+        fh.close()
+        try:
+            self.assertIsNone(_load_durations_file(fh.name, self.logger))
+        finally:
+            os.unlink(fh.name)
+
+    def test_non_object_json(self):
+        fh = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+        fh.write(b'[1, 2, 3]')
+        fh.close()
+        try:
+            self.assertIsNone(_load_durations_file(fh.name, self.logger))
+        finally:
+            os.unlink(fh.name)
+
+    def test_valid_json(self):
+        fh = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+        fh.write(json.dumps({'/a/test_foo.py': 12.5}).encode('utf-8'))
+        fh.close()
+        try:
+            durations = _load_durations_file(fh.name, self.logger)
+            self.assertEqual(durations, {'/a/test_foo.py': 12.5})
+        finally:
+            os.unlink(fh.name)
+
+
+class BinPackFilesTest(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger('test.nose_picker')
+
+    def test_balances_known_weights(self):
+        durations = {'/a.py': 10.0, '/b.py': 1.0, '/c.py': 1.0, '/d.py': 1.0}
+        keys = list(durations.keys())
+        bins, totals = _bin_pack_files(keys, durations, 2, self.logger)
+        # the one big file should be alone in a bin, balanced against the 3 small ones
+        self.assertEqual(sorted(sum(bins, [])), sorted(keys))
+        self.assertAlmostEqual(max(totals) - min(totals), 7.0)
+
+    def test_unknown_files_get_median_weight(self):
+        durations = {'/a.py': 10.0, '/b.py': 20.0}
+        keys = ['/a.py', '/b.py', '/unknown.py']
+        bins, totals = _bin_pack_files(keys, durations, 3, self.logger)
+        assigned = sum(bins, [])
+        self.assertEqual(sorted(assigned), sorted(keys))
+
+    def test_deterministic_tie_break_by_path(self):
+        durations = {}
+        keys = ['/z.py', '/a.py', '/m.py']
+        bins1, _ = _bin_pack_files(keys, durations, 3, self.logger)
+        bins2, _ = _bin_pack_files(list(reversed(keys)), durations, 3, self.logger)
+        self.assertEqual(bins1, bins2)
+
+
+class HashFilenameBackwardCompatTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmp)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tmp)
+
+    def test_stable_across_relative_and_absolute(self):
+        path = os.path.join(self.tmp, 'test_foo.py')
+        open(path, 'w').close()
+        self.assertEqual(hash_filename(path), hash_filename('test_foo.py'))
+
+
+class DiscoverCandidateFilesTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._make(['pkg/__init__.py'])
+        self._make(['pkg/test_foo.py'])
+        self._make(['pkg/bar_test.py'])
+        self._make(['pkg/helpers.py'])  # not test-like, must be excluded
+        self._make(['pkg/sub/__init__.py'])
+        self._make(['pkg/sub/test_deep.py'])
+        self._make(['lib/test_in_lib.py'])  # nose's srcDirs special case
+        self._make(['notpkg/test_should_not_appear.py'])  # non-package, non-testMatch dir
+        self._make(['_hidden/test_should_not_appear2.py'])  # leading underscore dir
+        self._make(['.dotdir/test_should_not_appear3.py'])  # leading dot dir
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def _make(self, rel_parts):
+        full = os.path.join(self.tmp, *rel_parts)
+        d = os.path.dirname(full)
+        if not os.path.isdir(d):
+            os.makedirs(d)
+        open(full, 'w').close()
+
+    def test_matches_nose_default_conventions(self):
+        candidates = discover_candidate_files(self.tmp)
+        rels = sorted(_relative_key(c, cwd=self.tmp) for c in candidates)
+        self.assertEqual(rels, sorted([
+            '/lib/test_in_lib.py',
+            '/pkg/bar_test.py',
+            '/pkg/sub/test_deep.py',
+            '/pkg/test_foo.py',
+        ]))
+
+
+class FullShardCoverageTest(unittest.TestCase):
+    """End-to-end style checks: across every shard 0..N-1, every discovered
+    file must be claimed by exactly one shard -- in legacy hash mode, in
+    duration mode, and in every fallback path duration mode can take.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.old_cwd = os.getcwd()
+        for rel in [
+            'pkg/__init__.py', 'pkg/test_foo.py', 'pkg/bar_test.py',
+            'pkg/helpers.py', 'pkg/sub/__init__.py', 'pkg/sub/test_deep.py',
+            'lib/test_in_lib.py',
+        ]:
+            full = os.path.join(self.tmp, rel)
+            d = os.path.dirname(full)
+            if not os.path.isdir(d):
+                os.makedirs(d)
+            open(full, 'w').close()
+        os.chdir(self.tmp)
+        self.expected_keys = sorted(
+            _relative_key(c, cwd=self.tmp)
+            for c in discover_candidate_files(self.tmp)
+        )
+        self.assertEqual(len(self.expected_keys), 4)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tmp)
+
+    def _run_all_shards(self, total_processes, file_durations=None):
+        assignment = {}
+        for which in range(total_processes):
+            plugin = NosePicker()
+            plugin.configure(
+                _make_options(which, total_processes, file_durations),
+                _FakeConfig(),
+            )
+            for full_path in discover_candidate_files(self.tmp):
+                key = _relative_key(full_path, cwd=self.tmp)
+                wanted = plugin._should_run(full_path) is None
+                if wanted:
+                    assignment.setdefault(key, []).append(which)
+        return assignment
+
+    def _assert_bijection(self, assignment):
+        self.assertEqual(sorted(assignment.keys()), self.expected_keys)
+        for key, shards in assignment.items():
+            self.assertEqual(len(shards), 1, 'file %s claimed by %r' % (key, shards))
+
+    def test_legacy_hash_mode(self):
+        assignment = self._run_all_shards(3, file_durations=None)
+        self._assert_bijection(assignment)
+
+    def test_duration_mode_fully_known(self):
+        durations = dict((k, random.uniform(1, 100)) for k in self.expected_keys)
+        path = os.path.join(self.tmp, 'durations.json')
+        with open(path, 'w') as fh:
+            json.dump(durations, fh)
+        assignment = self._run_all_shards(3, file_durations=path)
+        self._assert_bijection(assignment)
+
+    def test_duration_mode_stale_table_still_covers_everything(self):
+        path = os.path.join(self.tmp, 'partial.json')
+        with open(path, 'w') as fh:
+            json.dump({self.expected_keys[0]: 42.0}, fh)
+        assignment = self._run_all_shards(3, file_durations=path)
+        self._assert_bijection(assignment)
+
+    def test_missing_durations_file_falls_back_identically_to_legacy(self):
+        legacy = self._run_all_shards(3, file_durations=None)
+        fallback = self._run_all_shards(3, file_durations='/no/such/file.json')
+        self.assertEqual(legacy, fallback)
+
+    def test_invalid_json_falls_back_identically_to_legacy(self):
+        path = os.path.join(self.tmp, 'bad.json')
+        with open(path, 'w') as fh:
+            fh.write('{not valid json')
+        legacy = self._run_all_shards(3, file_durations=None)
+        fallback = self._run_all_shards(3, file_durations=path)
+        self.assertEqual(legacy, fallback)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_nose_plugin.py
+++ b/tests/test_nose_plugin.py
@@ -12,6 +12,7 @@ from picker.nose_plugin import (
     NosePicker,
     _bin_pack_files,
     _load_durations_file,
+    _looks_testlike,
     _median,
     _relative_key,
     hash_filename,
@@ -55,6 +56,21 @@ class _ListHandler(logging.Handler):
 
     def emit(self, record):
         self.messages.append(record.getMessage())
+
+
+class LooksTestlikeTest(unittest.TestCase):
+    """_looks_testlike is a best-effort, reporting-only heuristic (see its module-level comment)
+    -- it must never be used for selection, only to keep report()'s staleness metric from being
+    swamped by the ordinary non-test .py files nose also calls wantFile() for.
+    """
+
+    def test_testlike_names(self):
+        for name in ('test_foo.py', 'foo_test.py', 'Test_Foo.py', 'tests.py'):
+            self.assertTrue(_looks_testlike(name), name)
+
+    def test_non_testlike_names(self):
+        for name in ('helpers.py', '__init__.py', 'utils.py', 'models.py', 'views.py', 'contest.py'):
+            self.assertFalse(_looks_testlike(name), name)
 
 
 class MedianTest(unittest.TestCase):
@@ -122,6 +138,23 @@ class LoadDurationsFileTest(unittest.TestCase):
         try:
             durations = _load_durations_file(fh.name, self.logger)
             self.assertEqual(durations, {'/ok.py': 5.0})
+        finally:
+            os.unlink(fh.name)
+
+    def test_negative_values_are_dropped(self):
+        # Regression test: a negative duration is never physically meaningful (nothing stops a
+        # corrupt file or a buggy upstream aggregator from producing one), and is dangerous in a
+        # different way than NaN/Infinity: it *lowers* whichever bin it's added to during
+        # bin-packing, so the LPT loop keeps preferring that artificially-cheap bin for every
+        # later placement and piles most of the suite onto it. Must be dropped at ingestion, same
+        # as NaN/Infinity and any other invalid value. Zero is fine (legitimately measured for a
+        # trivial/empty test file).
+        fh = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+        fh.write(json.dumps({'/negative.py': -5.0, '/zero.py': 0.0, '/ok.py': 5.0}).encode('utf-8'))
+        fh.close()
+        try:
+            durations = _load_durations_file(fh.name, self.logger)
+            self.assertEqual(durations, {'/zero.py': 0.0, '/ok.py': 5.0})
         finally:
             os.unlink(fh.name)
 
@@ -223,6 +256,26 @@ class BinPackFilesTest(unittest.TestCase):
         bins, totals = _bin_pack_files(keys, durations, 2, self.logger)
         self.assertIsNone(bins)
         self.assertIsNone(totals)
+
+    def test_negative_weight_does_not_skew_bins(self):
+        # Regression test: a negative duration artificially lowers whichever bin it's placed
+        # into, making the LPT loop keep preferring that bin for every later placement and piling
+        # most of the suite onto it -- unlike NaN, this doesn't collapse everything onto one bin
+        # via broken comparisons, it just badly imbalances the result. _bin_pack_files must treat
+        # a negative entry exactly like a missing one (falls back to the median), same defensive
+        # re-sanitization as the NaN case above.
+        durations = {
+            '/a.py': 10.0, '/b.py': 10.0, '/c.py': 10.0, '/d.py': 10.0,
+            '/negative.py': -1000.0,
+        }
+        keys = list(durations.keys())
+        bins, totals = _bin_pack_files(keys, durations, 2, self.logger)
+        self.assertIsNotNone(bins)
+        self.assertEqual(sorted(sum(bins, [])), sorted(keys))
+        # A poisoned negative weight would otherwise make one bin's total go deeply negative and
+        # never lose the "cheapest bin" comparison again, piling everything else onto it -- assert
+        # the two bins are still reasonably balanced instead.
+        self.assertLess(abs(totals[0] - totals[1]), 15.0)
 
 
 class HashFilenameBackwardCompatTest(unittest.TestCase):
@@ -419,6 +472,33 @@ class ReportStalenessWarningTest(unittest.TestCase):
         self.logger_handler.messages = []
         self.plugin.report(None)
         self.assertEqual(self.logger_handler.messages, [])
+
+    def test_non_testlike_files_do_not_inflate_staleness_metric(self):
+        # Regression test: nose's Selector.wantFile calls every plugin's wantFile() hook for
+        # *every* non-ignored .py file it walks, not just test-like ones (testMatch only decides
+        # nose's own default answer once every plugin has abstained). A flood of ordinary,
+        # non-test source files -- none in the durations table, since that table only ever
+        # contains real test-file keys -- must not count toward the unknown-hit staleness metric,
+        # or the warning would fire constantly regardless of whether the table is actually fresh.
+        durations_path = os.path.join(self.tmp, 'durations.json')
+        with open(durations_path, 'w') as fh:
+            json.dump({_relative_key(os.path.join(self.tmp, 'test_known.py'), cwd=self.tmp): 5.0}, fh)
+        self.plugin.configure(_make_options(0, 2, durations_path), _FakeConfig())
+
+        self._visit(
+            'test_known.py',
+            # a "flood" of ordinary source files nose also visits via wantFile(), none of which
+            # look test-like and none of which are (or ever would be) in the durations table
+            'helpers.py', '__init__.py', 'utils.py', 'models.py', 'views.py', 'serializers.py',
+            'urls.py', 'admin.py', 'forms.py', 'managers.py',
+        )
+        self.logger_handler.messages = []
+        self.plugin.report(None)
+
+        self.assertFalse(
+            any('durations cache may be stale' in msg for msg in self.logger_handler.messages),
+            self.logger_handler.messages,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_nose_plugin.py
+++ b/tests/test_nose_plugin.py
@@ -109,6 +109,22 @@ class LoadDurationsFileTest(unittest.TestCase):
         finally:
             os.unlink(fh.name)
 
+    def test_nan_and_infinity_values_are_dropped(self):
+        # Regression test: Python's json module accepts bare NaN/Infinity/-Infinity literals by
+        # default (a non-standard extension) -- a corrupt or hand-edited durations file can
+        # produce these even though float(value) "succeeds". A NaN weight breaks every comparison
+        # downstream (NaN is never <, >, or == anything, including itself), which can silently
+        # collapse the whole LPT bin-packing loop onto a single shard. These must be dropped at
+        # ingestion, same as any other value that fails to parse as a float.
+        fh = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+        fh.write(b'{"/nan.py": NaN, "/inf.py": Infinity, "/neg_inf.py": -Infinity, "/ok.py": 5.0}')
+        fh.close()
+        try:
+            durations = _load_durations_file(fh.name, self.logger)
+            self.assertEqual(durations, {'/ok.py': 5.0})
+        finally:
+            os.unlink(fh.name)
+
 
 class BinPackFilesTest(unittest.TestCase):
     def setUp(self):
@@ -182,6 +198,31 @@ class BinPackFilesTest(unittest.TestCase):
         # `bin_totals.index(min(...))` tie-break happened to pick first (the bug this regression
         # test covers would have produced something like [0, 0, 6] here).
         self.assertEqual(zero_weight_bin_sizes, [0, 3, 3])
+
+    def test_nan_weight_does_not_collapse_bins(self):
+        # Regression test: _bin_pack_files defensively re-sanitizes its own `durations` input
+        # (not just relying on _load_durations_file() having already done so), since a NaN value
+        # anywhere in it breaks ordinary float comparisons (NaN is never <, >, or == anything,
+        # including itself) badly enough to silently collapse the whole LPT loop onto one shard.
+        # A NaN entry must be treated exactly like a missing one -- falls back to the median.
+        durations = {
+            '/a.py': 10.0, '/b.py': 20.0, '/c.py': 30.0,
+            '/nan.py': float('nan'),
+        }
+        keys = list(durations.keys())
+        bins, totals = _bin_pack_files(keys, durations, 3, self.logger)
+        self.assertIsNotNone(bins)
+        self.assertEqual(sorted(sum(bins, [])), sorted(keys))
+        # every bin actually got at least one file -- the collapse bug this guards against would
+        # have dumped everything onto a single bin instead.
+        self.assertTrue(all(b for b in bins), bins)
+
+    def test_all_nan_durations_signals_fallback(self):
+        keys = ['/a.py', '/b.py']
+        durations = dict((k, float('nan')) for k in keys)
+        bins, totals = _bin_pack_files(keys, durations, 2, self.logger)
+        self.assertIsNone(bins)
+        self.assertIsNone(totals)
 
 
 class HashFilenameBackwardCompatTest(unittest.TestCase):


### PR DESCRIPTION
## What

Adds an **opt-in** `--file-durations=<path>` flag. `<path>` is a JSON file
shaped like `{relative_file_path: total_seconds}`, using the exact same
relative-path convention `hash_filename()` has always used (strip the cwd,
or failing that a site-packages prefix, off the realpath).

When a valid file is given, nose-picker bin-packs that file set across
`--total-processes` bins by descending duration (greedy LPT -- longest
processing time first), so shards end up balanced by *total runtime*
instead of by *file count*. `wantFile()` becomes a simple membership check
against the bin assigned to `self.which_process`, computed once in
`configure()` (before collection starts), instead of a per-file hash
computation.

**Nose's own real discovery is untouched.** nose-picker does **not** walk
the filesystem itself to build a candidate list -- the candidate set for
bin-packing is simply the durations table's own key set (real ground truth
from a prior actual run's junit output), and nose's own `Loader`/`Selector`
keeps calling `wantFile()` once per file, one at a time, exactly as it
always has (see "Design evolution" below for why an earlier version of
this PR did try to walk the filesystem itself, and why that was dropped).
A file nose visits that the durations table doesn't cover (new since the
table was last refreshed, or for any other reason) falls back to the
classic hash for that one file, so it still runs in exactly one shard
rather than vanishing from all of them.

## Backward compatibility (the important part)

If `--file-durations` is **not passed at all**, or the given path doesn't
exist, isn't readable, or doesn't parse as valid JSON, behavior is
**exactly** the prior `hash_filename(name) % total_processes` selection,
byte-for-byte unchanged. This is deliberate and load-bearing: nose-picker
has other consumers besides the one motivating this change, and none of
them should see any behavior difference unless they explicitly opt in.

The entire duration-mode configuration path is wrapped so that *any*
unexpected failure degrades to the classic hash-based selection rather than
propagating and breaking CI for everyone. There's also a per-file safety
net (described above): an individual file the durations table doesn't cover
falls back to the hash for just that file.

Verified with an integration test that simulates all N shards at once and
checks the file set gets an exact 1:1 (no missing, no duplicated)
assignment across shards -- in legacy hash mode, in full duration mode,
with a partially/wholly-unmatched durations table, and in every fallback
path (missing file, invalid JSON, all-zero/NaN durations) -- and that those
fallback paths produce an assignment *identical* to pure legacy mode.

## Known ceiling -- please read before over-trusting this

Bin-packing here only ever operates at **whole-file granularity**, because
nose's `wantFile` hook never sees inside a file -- there's no mechanism to
split one file's tests across shards. If a single test file is much slower
than an even share of the whole suite, no bin-packing scheme built on this
hook can even out wall-clock time across shards; that one file's duration
becomes a floor for whichever shard it lands in. This helps a lot when
slowness is spread across many files (the common case), much less when
it's concentrated in one pathologically slow file (the fix there is
splitting that file, not a smarter scheduler).

## Design evolution during review (kept here for the audit trail)

This PR went through a meaningful redesign based on review feedback, plus
three bugbot-flagged-and-fixed rounds. Summarized here since the commit
history has all the detail:

1. **v1**: nose-picker did its own filesystem walk in `configure()`,
   reimplementing nose's *default* discovery convention (`testMatch`/
   `ignoreFiles`/`srcDirs`/package detection) to build a complete candidate
   list up front, since `wantFile()` alone never exposes the full set.
2. **Bugbot round 1**: a durations table with no usable timing signal at
   all (empty overlap, or every covered value `<= 0`) collapsed the entire
   LPT bin-packing loop onto shard 0 -- fixed by having the bin-packer
   signal "can't bin-pack" and fall back to hash mode, plus a follow-up fix
   for a narrower version of the same clumping bug with partial (not just
   total) zero-weight files, via a fairer tie-break rule.
3. **Bugbot round 2**: found a real symlink-duplication bug (fixed --
   `discover_candidate_files()` now deduped by `os.path.realpath()`) and a
   claimed basename-vs-full-path discovery mismatch that, on empirical
   verification against real nose 1.3.7 (not just source-reading), turned
   out to be a false positive -- nose really does only match a bare
   basename, confirmed by three separate fixture runs through actual
   `nosetests -v`. Documented, not "fixed" (the suggested change would have
   made discovery *more* permissive than real nose).
4. **Architectural change**: rather than keep hardening a from-scratch
   reimplementation of nose's discovery rules (however well-verified),
   dropped it entirely. The risk that motivated this -- any future
   divergence between the reimplementation and nose's actual behavior could
   silently drop a file from every shard, a correctness bug, not just a
   balance one -- goes away completely if nose-picker never tries to
   rediscover files itself. The candidate set is now just the durations
   table's own keys; nose's real discovery drives everything else, same as
   the original 0.5.7. Test suite rewritten to match (no more filesystem
   fixtures needed to exercise bin-packing at all).
5. **Bugbot round 3**: found that Python's `json` module accepts bare
   `NaN`/`Infinity`/`-Infinity` literals by default, and a `NaN` duration
   value broke the same downstream comparisons as round 1's bug (NaN is
   never `<`, `>`, or `==` anything, including itself) -- fixed by rejecting
   non-finite values at ingestion, plus defensively inside the bin-packer
   itself.

Current state: 28 tests, all passing under real nose 1.3.7 on Python 2.7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in sharding logic is correctness-sensitive (every test file must map to exactly one shard), but failures fall back to legacy hashing and the PR adds broad regression coverage for collapse/imbalance cases.
> 
> **Overview**
> **0.6.0** adds an opt-in **`--file-durations`** JSON path so parallel shards can be balanced by **total runtime** (greedy LPT bin-packing in `configure()`) instead of only hash-modulo file count. Bin-packing uses the durations table’s keys as the candidate set—nose still drives discovery via `wantFile()`; known files are membership-checked per shard, and files not in the table fall back to the classic hash so each file still lands on exactly one shard.
> 
> Path handling is refactored through **`_relative_key()`** so JSON keys match **`hash_filename()`**. Invalid or missing duration data, unusable timing (e.g. all zeros/NaN), and configure errors all **degrade to unchanged hash behavior** when the flag is omitted or broken. **`report()`** can warn when too many test-like visited files were unknown to the table; a reporting-only **`_looks_testlike`** heuristic avoids noise from non-test `.py` files.
> 
> README documents the feature and limits (whole-file granularity). A large new **`tests/test_nose_plugin.py`** covers bin-packing edge cases, fallbacks, shard bijection, and staleness warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edeb49dbb140a28df0c6ddc7dc2c4a5ff9f0a431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->